### PR TITLE
Add arm64 support to Linux release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,19 @@ jobs:
   build-linux:
     name: Build Linux release bundles
     needs: prepare-release
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            platform_label: linux
+            arch_label: x64
+            artefact_name: linux-release-assets-x64
+          - runner: ubuntu-24.04-arm
+            platform_label: linux
+            arch_label: arm64
+            artefact_name: linux-release-assets-arm64
     container:
       image: ghcr.io/liminal-hq/tauri-ci-desktop:latest
       credentials:
@@ -265,7 +277,7 @@ jobs:
         id: upload_assets
         uses: actions/upload-artifact@v7
         with:
-          name: linux-release-assets
+          name: ${{ matrix.artefact_name }}
           path: release-assets/linux/**
           if-no-files-found: error
 
@@ -281,8 +293,10 @@ jobs:
           {
             echo "## Emoji Nook Linux Release Summary"
             echo
-            echo "- Runner: \`ubuntu-24.04\`"
+            echo "- Runner: \`${{ matrix.runner }}\`"
             echo "- Container: \`ghcr.io/liminal-hq/tauri-ci-desktop:latest\`"
+            echo "- Platform: \`${{ matrix.platform_label }}\`"
+            echo "- Architecture: \`${{ matrix.arch_label }}\`"
             echo "- Release tag: \`${{ needs.prepare-release.outputs.tag_name }}\`"
             echo "- Build and bundle: \`${{ steps.build_tauri.outcome }}\`"
             echo "- Collect assets: \`${{ steps.collect_assets.outcome }}\`"
@@ -309,8 +323,9 @@ jobs:
       - name: Download Linux release assets
         uses: actions/download-artifact@v5
         with:
-          name: linux-release-assets
+          pattern: linux-release-assets-*
           path: release-assets/linux
+          merge-multiple: true
 
       - name: Upload assets to GitHub Release
         id: upload_release_assets

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ pnpm tauri:build
 
 ## Releasing
 
-Release policy and maintainer workflow live in [docs/releasing.md](docs/releasing.md). The release workflow is checked in, and version preparation has dedicated helper commands:
+Release policy and maintainer workflow live in [docs/releasing.md](docs/releasing.md). The release workflow is checked in for Linux `x64` and `arm64` builds, and version preparation has dedicated helper commands:
 
 ```bash
 pnpm release:version:check

--- a/docs/implementation-plans/releasing.md
+++ b/docs/implementation-plans/releasing.md
@@ -17,7 +17,7 @@ The repository already has a good base for release work, but several pieces are 
 - Linux icons are present for bundle generation
 - Release/versioning policy is now documented in `docs/releasing.md`
 - GitHub-generated release notes are now the defined baseline policy, while signing and updater strategy remain pending
-- A checked-in GitHub release workflow now exists in `.github/workflows/release.yml`
+- A checked-in GitHub release workflow now exists in `.github/workflows/release.yml`, with Linux `x64` and `arm64` build coverage
 - A release-prep helper script and CI version drift check now exist
 - A maintainer release checklist now exists under `docs/release-checklist.md`
 - Linux package dependency metadata is still intentionally minimal pending the first end-to-end release validation
@@ -230,6 +230,7 @@ Automate Linux builds and GitHub Releases.
   - Creates or reuses the GitHub Release
   - Exposes `tag_name` and `release_id` outputs for later jobs
 - [x] Build on GitHub-hosted Ubuntu runners using the shared GHCR Docker image pattern already established in `liminal-hq/.github` where possible
+- [x] Build Linux release artefacts in an architecture matrix covering `x64` and `arm64`
 - [x] Decide whether Emoji Nook can consume the shared desktop CI image directly or needs a small derived image for any extra Linux packaging dependencies
 - [x] Run `pnpm install --frozen-lockfile`
 - [x] Run the Tauri production build for the app

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -45,9 +45,9 @@ Releases should be cut by a maintainer who has:
 
 1. Open the release URL from the workflow summary.
 2. Confirm the release contains:
-   - AppImage
-   - `.deb`
-   - `.rpm`
+   - AppImage bundles for the Linux architectures we currently publish
+   - `.deb` bundles for the Linux architectures we currently publish
+   - `.rpm` bundles for the Linux architectures we currently publish
    - `SHA256SUMS`
 3. Review the generated release notes and add any missing operator guidance:
    - installation notes that matter for this release

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -4,7 +4,7 @@ This document records the current release policy for Emoji Nook so documentation
 
 ## Current status
 
-CI validation is in place, a release version-drift check now runs in CI, and `.github/workflows/release.yml` defines the Linux GitHub Release flow for AppImage, `.deb`, `.rpm`, and `SHA256SUMS`.
+CI validation is in place, a release version-drift check now runs in CI, and `.github/workflows/release.yml` defines the Linux GitHub Release flow for `x64` and `arm64` AppImage, `.deb`, `.rpm`, and `SHA256SUMS` assets.
 
 Treat this document and [docs/release-checklist.md](docs/release-checklist.md) as the source of truth for release decisions and operator steps.
 
@@ -58,7 +58,7 @@ The repository does not maintain a separate `CHANGELOG.md` at this stage.
 
 ## Planned release artefacts
 
-The first public release target is Linux only, with these artefacts attached to GitHub Releases:
+The first public release target is Linux only, with these artefacts attached to GitHub Releases for both `x64` and `arm64` where bundling succeeds:
 
 - AppImage
 - `.deb`


### PR DESCRIPTION
## Summary

- **Release workflow** expands [`.github/workflows/release.yml`](.github/workflows/release.yml) from a single Linux build job into an `x64` and `arm64` matrix so GitHub Releases can stage artefacts on both Ubuntu runner architectures
- **Release publishing** updates the publish job to download and merge the per-architecture staged artefacts before attaching them to the GitHub Release, keeping the existing release flow intact while broadening Linux coverage
- **Workflow summaries** now include the Linux architecture alongside the runner and container details so maintainers can see which build produced which staged artefacts from the Actions UI alone
- **Release documentation** updates the README, release guide, release checklist, and release implementation plan so the documented Linux release surface matches the new `x64` plus `arm64` workflow behaviour

### Maintainer-facing changes

- **Linux release coverage** now matches the pattern already used in `Threshold` and `liminal-notes`, with separate GitHub-hosted Ubuntu runners for `x64` and `arm64`
- **Staged artefact handling** now keeps the architecture-specific build jobs independent and combines their outputs only at publish time, which makes failures easier to isolate and reruns easier to reason about
- **Operator expectations** now explicitly describe that Linux release assets are published per architecture where bundling succeeds

### Packaging behaviour

- **Matrix builds** run the shared GHCR desktop CI container on both `ubuntu-24.04` and `ubuntu-24.04-arm`
- **Release artefact staging** now uses one uploaded artefact bundle per architecture and merges them during the publish step
- **Release notes and checklist guidance** continue to describe AppImage, `.deb`, `.rpm`, and `SHA256SUMS`, but now frame them as architecture-specific Linux outputs

### Known limitations

- **Local arm64 execution** cannot be exercised from this x64 development environment, so the arm64 addition is validated by workflow structure rather than a local runner execution
- **AppImage validation** is still subject to the existing local `linuxdeploy` limitation on this machine; this change only broadens the release matrix and does not alter the underlying AppImage tooling path

## Test plan

- [x] `pnpm format:check`
- [x] `python3` YAML parse of `.github/workflows/release.yml`
- [ ] Run the arm64 GitHub Actions job end-to-end (requires GitHub-hosted `ubuntu-24.04-arm` runner execution)
