### PR TITLE
Fix release workflow shell handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,10 @@ concurrency:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   prepare-release:
     name: Prepare release


### PR DESCRIPTION
## Summary
- **Release workflow shell:** set `defaults.run.shell` to `bash` so release job scripts run under Bash consistently, including in container jobs.
- **Release asset collection:** prevent the tagged release path from failing when the workflow reaches Bash-only syntax such as `set -o pipefail`, `[[ ... ]]`, and `mapfile`.
- **Behaviour:** keep the existing release logic intact while making the shell environment match the workflow script syntax already in use.

## Test plan
- [x] Inspect the failed release logs and confirm the breakage came from `sh` rejecting `set -o pipefail`.
- [x] Verify the workflow now declares `defaults.run.shell: bash`.
- [ ] Re-run the release workflow for the affected tag after this PR merges.
