### PR TITLE
Fix release asset upload repository targeting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -335,6 +335,7 @@ jobs:
         id: upload_release_assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ needs.prepare-release.outputs.tag_name }}
         run: gh release upload "${TAG_NAME}" release-assets/linux/* --clobber
 


### PR DESCRIPTION
## Summary
- **Release upload targeting:** set `GH_REPO` in the publish job so `gh release upload` targets `liminal-hq/emoji-nook` explicitly instead of relying on local Git metadata.
- **Publish job behaviour:** keep the final release job compatible with its current shape, where it downloads artefacts but does not check out the repository.
- **Failure addressed:** prevent the `fatal: not a git repository` error seen while uploading assets to the GitHub Release.

## Test plan
- [x] Inspect the failed release logs from run `23178546338` and confirm the publish job failed because `gh` could not infer the repository without a `.git` directory.
- [x] Verify the workflow now exports `GH_REPO: ${{ github.repository }}` in the upload step.
- [ ] Re-run the release workflow for the affected tag after this PR merges.
