### PR TITLE
Improve Cinnamon/X11 picker focus with native window activation timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4152,6 +4152,7 @@ dependencies = [
  "gtk",
  "log",
  "tauri",
+ "tauri-plugin",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4147,6 +4147,9 @@ dependencies = [
 name = "tauri-plugin-desktop-integration"
 version = "0.1.0"
 dependencies = [
+ "gdk",
+ "gdkx11",
+ "gtk",
  "log",
  "tauri",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,6 +1000,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
+ "tauri-plugin-desktop-integration",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-log",
  "tauri-plugin-opener",
@@ -4140,6 +4141,14 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-desktop-integration"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "tauri",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "apps/emoji-picker/src-tauri",
+  "plugins/desktop-integration",
   "plugins/xdg-portal"
 ]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -16,20 +16,31 @@ This repository is a `pnpm` + Cargo workspace monorepo.
 
 - `apps/emoji-picker/` — React 19 + TypeScript frontend
 - `apps/emoji-picker/src-tauri/` — Rust/Tauri v2 backend
+- `plugins/desktop-integration/` — Custom Tauri plugin for backend desktop activation helpers
+- `plugins/desktop-integration/guest-js/` — Guest package placeholder for future frontend helpers
 - `plugins/xdg-portal/` — Custom Tauri plugin bridging `xdg-desktop-portal` via `ashpd`
 - `plugins/xdg-portal/guest-js/` — TypeScript guest API for the plugin
 
 ### Key dependencies
 
-| Layer     | Library                                                   | Purpose                                    |
-| --------- | --------------------------------------------------------- | ------------------------------------------ |
-| Emoji     | [Frimousse](https://github.com/liveblocks/frimousse) v0.3 | Headless, React 19 compatible emoji picker |
-| Portal    | [ashpd](https://github.com/bilelmoussaoui/ashpd)          | D-Bus interface to `xdg-desktop-portal`    |
-| Framework | [Tauri](https://v2.tauri.app/) v2                         | Desktop application shell                  |
-| Clipboard | [arboard](https://crates.io/crates/arboard)               | Cross-platform clipboard access            |
-| Settings  | tauri-plugin-store                                        | Persistent JSON key-value store            |
-| Autostart | tauri-plugin-autostart                                    | XDG autostart desktop file management      |
-| Logging   | tauri-plugin-log                                          | Structured logging with console bridge     |
+| Layer          | Library                                                   | Purpose                                    |
+| -------------- | --------------------------------------------------------- | ------------------------------------------ |
+| Emoji          | [Frimousse](https://github.com/liveblocks/frimousse) v0.3 | Headless, React 19 compatible emoji picker |
+| Portal plugin  | tauri-plugin-xdg-portal                                   | Tauri bridge to desktop portal features    |
+| Portal backend | [ashpd](https://github.com/bilelmoussaoui/ashpd)          | D-Bus interface to `xdg-desktop-portal`    |
+| Framework      | [Tauri](https://v2.tauri.app/) v2                         | Desktop application shell                  |
+| Activation     | tauri-plugin-desktop-integration                          | Native X11 user-time activation            |
+| Clipboard      | [arboard](https://crates.io/crates/arboard)               | Cross-platform clipboard access            |
+| Settings       | tauri-plugin-store                                        | Persistent JSON key-value store            |
+| Autostart      | tauri-plugin-autostart                                    | XDG autostart desktop file management      |
+| Logging        | tauri-plugin-log                                          | Structured logging with console bridge     |
+
+### Desktop integration
+
+Emoji Nook uses two custom workspace plugins for desktop integration:
+
+- `tauri-plugin-xdg-portal` handles theme detection and Wayland-facing portal integration.
+- `tauri-plugin-desktop-integration` handles backend-only X11 activation quirks such as GTK `present_with_time(...)` and `_NET_WM_USER_TIME` stamping on fresh picker windows.
 
 ### Desktop theme support
 

--- a/apps/emoji-picker/README.md
+++ b/apps/emoji-picker/README.md
@@ -1,7 +1,24 @@
-# Tauri + React + Typescript
+# Emoji Picker
 
-This template should help get you started developing with Tauri, React and Typescript in Vite.
+Emoji Nook is a tray-backed Tauri desktop emoji picker for Linux. The app keeps a background process alive for the tray icon, global shortcut, settings store, and injection pipeline, then creates a fresh picker window each time you open it.
 
-## Recommended IDE Setup
+## Development
 
-- [VS Code](https://code.visualstudio.com/) + [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode) + [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
+From the workspace root:
+
+- `pnpm dev` runs the app in development mode
+- `pnpm build` builds the frontend package
+- `pnpm lint` runs the shared frontend lint pass
+- `pnpm typecheck` runs the shared TypeScript checks
+
+## Window Lifecycle
+
+The picker window is intentionally disposable:
+
+- the app process starts in the background with no picker window at all
+- showing the picker closes any stale picker window and creates a fresh `picker-*` window from the Tauri window config
+- selecting an emoji, pressing `Esc`, or losing focus closes the picker window entirely
+
+This keeps each activation on a clean UI state and gives X11 window managers a genuinely fresh window to focus.
+
+On X11, the app also uses the desktop-integration plugin to request a stronger activation handoff after the picker window appears. That is what makes repeated shortcut opens behave reliably under Cinnamon/Muffin.

--- a/apps/emoji-picker/README.md
+++ b/apps/emoji-picker/README.md
@@ -22,3 +22,10 @@ The picker window is intentionally disposable:
 This keeps each activation on a clean UI state and gives X11 window managers a genuinely fresh window to focus.
 
 On X11, the app also uses the desktop-integration plugin to stamp the fresh picker window with native GTK/X11 user-time metadata and present it with that timestamp. That native handoff is what makes repeated shortcut opens behave reliably under Cinnamon/Muffin.
+
+The desktop-integration plugin now follows the same first-class workspace shape as the xdg-portal plugin:
+
+- `build.rs` generates the Tauri plugin metadata and permission manifests
+- `permissions/default.toml` defines the plugin's default grant
+- `guest-js/` provides a stable guest package, even though the plugin is backend-only today
+- [`plugins/desktop-integration/README.md`](../../plugins/desktop-integration/README.md) documents the plugin's role and current limits

--- a/apps/emoji-picker/README.md
+++ b/apps/emoji-picker/README.md
@@ -21,4 +21,4 @@ The picker window is intentionally disposable:
 
 This keeps each activation on a clean UI state and gives X11 window managers a genuinely fresh window to focus.
 
-On X11, the app also uses the desktop-integration plugin to stamp the fresh picker window with native GTK/X11 user-time metadata and present it with that timestamp. If the window manager still does not hand over focus cleanly, the plugin falls back to an `xdotool` activation nudge. That is what makes repeated shortcut opens behave reliably under Cinnamon/Muffin.
+On X11, the app also uses the desktop-integration plugin to stamp the fresh picker window with native GTK/X11 user-time metadata and present it with that timestamp. That native handoff is what makes repeated shortcut opens behave reliably under Cinnamon/Muffin.

--- a/apps/emoji-picker/README.md
+++ b/apps/emoji-picker/README.md
@@ -21,4 +21,4 @@ The picker window is intentionally disposable:
 
 This keeps each activation on a clean UI state and gives X11 window managers a genuinely fresh window to focus.
 
-On X11, the app also uses the desktop-integration plugin to request a stronger activation handoff after the picker window appears. That is what makes repeated shortcut opens behave reliably under Cinnamon/Muffin.
+On X11, the app also uses the desktop-integration plugin to stamp the fresh picker window with native GTK/X11 user-time metadata and present it with that timestamp. If the window manager still does not hand over focus cleanly, the plugin falls back to an `xdotool` activation nudge. That is what makes repeated shortcut opens behave reliably under Cinnamon/Muffin.

--- a/apps/emoji-picker/src-tauri/Cargo.toml
+++ b/apps/emoji-picker/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ arboard = "3"
 log = "0.4"
 tauri = { workspace = true }
 tauri-plugin-autostart = { workspace = true }
+tauri-plugin-desktop-integration = { path = "../../../plugins/desktop-integration" }
 tauri-plugin-global-shortcut = { workspace = true }
 tauri-plugin-log = "2"
 tauri-plugin-opener = "2"

--- a/apps/emoji-picker/src-tauri/capabilities/default.json
+++ b/apps/emoji-picker/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
 		"core:default",
 		"core:window:allow-start-dragging",
 		"autostart:default",
+		"desktop-integration:default",
 		"global-shortcut:default",
 		"log:default",
 		"opener:default",

--- a/apps/emoji-picker/src-tauri/capabilities/default.json
+++ b/apps/emoji-picker/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
 	"$schema": "../gen/schemas/desktop-schema.json",
 	"identifier": "default",
 	"description": "Capability for the main window",
-	"windows": ["main"],
+	"windows": ["picker-*"],
 	"permissions": [
 		"core:default",
 		"core:window:allow-start-dragging",

--- a/apps/emoji-picker/src-tauri/src/lib.rs
+++ b/apps/emoji-picker/src-tauri/src/lib.rs
@@ -149,7 +149,7 @@ fn present_picker(app: &AppHandle, source: &'static str) {
 /// Receives a selected emoji from the frontend, hides the picker,
 /// and injects the emoji into the previously focused application.
 #[tauri::command]
-fn insert_emoji(app: AppHandle, emoji: String, label: &str) {
+fn insert_emoji(app: AppHandle, emoji: String, label: &str, close_on_select: bool) {
     info!("emoji selected: {} ({})", emoji, label);
 
     // Close the picker first so focus returns to the target app with a
@@ -158,8 +158,12 @@ fn insert_emoji(app: AppHandle, emoji: String, label: &str) {
 
     // Inject on a background thread to avoid blocking the IPC handler
     // during the sleep-based clipboard shuffle
+    let reopen_handle = app.clone();
     std::thread::spawn(move || {
         injection::clipboard_shuffle(&emoji);
+        if !close_on_select {
+            present_picker(&reopen_handle, "post-select-reopen");
+        }
     });
 }
 

--- a/apps/emoji-picker/src-tauri/src/lib.rs
+++ b/apps/emoji-picker/src-tauri/src/lib.rs
@@ -7,10 +7,12 @@ mod injection;
 
 use log::info;
 use std::ffi::OsStr;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Mutex;
 use tauri::image::Image;
 use tauri::menu::{MenuBuilder, MenuItemBuilder};
 use tauri::tray::TrayIconBuilder;
-use tauri::{AppHandle, Emitter, Manager};
+use tauri::{AppHandle, Manager, RunEvent, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
 use tauri_plugin_store::StoreExt;
 
 fn has_wayland_display(value: Option<&OsStr>) -> bool {
@@ -18,6 +20,13 @@ fn has_wayland_display(value: Option<&OsStr>) -> bool {
 }
 
 const DEFAULT_SHORTCUT: &str = "Alt+Shift+E";
+
+#[derive(Default)]
+struct LifecycleState {
+    quit_requested: AtomicBool,
+    picker_counter: AtomicUsize,
+    current_picker_label: Mutex<Option<String>>,
+}
 
 /// Reads the saved shortcut from the settings store, falling back to the default.
 fn load_saved_shortcut(app: &AppHandle) -> String {
@@ -38,19 +47,117 @@ fn is_wayland() -> bool {
     has_wayland_display(std::env::var_os("WAYLAND_DISPLAY").as_deref())
 }
 
+fn set_current_picker_label(app: &AppHandle, label: Option<String>) {
+    if let Ok(mut current_label) = app.state::<LifecycleState>().current_picker_label.lock() {
+        *current_label = label;
+    }
+}
+
+fn current_picker_label(app: &AppHandle) -> Option<String> {
+    app.state::<LifecycleState>()
+        .current_picker_label
+        .lock()
+        .ok()
+        .and_then(|label| label.clone())
+}
+
 fn load_app_icon() -> tauri::Result<Image<'static>> {
     Image::from_bytes(include_bytes!("../icons/icon.png"))
 }
+
+fn close_picker_window(app: &AppHandle) {
+    if let Some(label) = current_picker_label(app) {
+        if let Some(window) = app.get_webview_window(&label) {
+            let _ = window.close();
+        }
+    }
+
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.close();
+    }
+
+    set_current_picker_label(app, None);
+}
+
+fn create_picker_window(app: &AppHandle, label: &str) -> tauri::Result<WebviewWindow> {
+    let mut builder = WebviewWindowBuilder::new(app, label, WebviewUrl::App("index.html".into()))
+        .title("Emoji Nook")
+        .inner_size(370.0, 380.0)
+        .resizable(false)
+        .decorations(false)
+        .transparent(true)
+        .always_on_top(true)
+        .skip_taskbar(true)
+        .center();
+
+    builder = builder.icon(load_app_icon()?)?;
+
+    builder.build()
+}
+
+fn log_picker_focus_state(app: &AppHandle, source: &'static str, label: String, delay_ms: u64) {
+    let handle = app.clone();
+
+    std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+
+        if let Some(window) = handle.get_webview_window(&label) {
+            let visible = window.is_visible().unwrap_or(false);
+            let focused = window.is_focused().unwrap_or(false);
+            info!(
+                "picker focus probe ({source}) label={label} delay={}ms visible={} focused={}",
+                delay_ms, visible, focused
+            );
+        } else {
+            info!(
+                "picker focus probe ({source}) label={label} delay={}ms window-missing",
+                delay_ms
+            );
+        }
+    });
+}
+
+fn present_picker(app: &AppHandle, source: &'static str) {
+    info!("presenting picker from {source}");
+    close_picker_window(app);
+    let picker_id = app
+        .state::<LifecycleState>()
+        .picker_counter
+        .fetch_add(1, Ordering::SeqCst);
+    let label = format!("picker-{picker_id}");
+
+    match create_picker_window(app, &label) {
+        Ok(window) => {
+            info!("created picker window label={label} from {source}");
+            set_current_picker_label(app, Some(label.clone()));
+            let _ = window.center();
+            let _ = window.show();
+            let _ = window.set_focus();
+            if !is_wayland() {
+                tauri_plugin_desktop_integration::request_activation_assist(
+                    source,
+                    "Emoji Nook",
+                    &label,
+                );
+            }
+            log_picker_focus_state(app, source, label.clone(), 75);
+            log_picker_focus_state(app, source, label, 225);
+        }
+        Err(error) => {
+            log::error!("failed to create picker window from {source}: {error}");
+        }
+    }
+}
+
 /// Receives a selected emoji from the frontend, hides the picker,
 /// and injects the emoji into the previously focused application.
 #[tauri::command]
 fn insert_emoji(app: AppHandle, emoji: String, label: &str) {
     info!("emoji selected: {} ({})", emoji, label);
 
-    // Hide the picker first so focus returns to the target app
-    if let Some(window) = app.get_webview_window("main") {
-        let _ = window.hide();
-    }
+    // Close the picker first so focus returns to the target app with a
+    // brand-new window created the next time it is shown.
+    close_picker_window(&app);
 
     // Inject on a background thread to avoid blocking the IPC handler
     // during the sleep-based clipboard shuffle
@@ -63,20 +170,13 @@ fn insert_emoji(app: AppHandle, emoji: String, label: &str) {
 /// can reset its state (clear search, focus input, scroll to top).
 #[tauri::command]
 fn show_picker(app: AppHandle) {
-    if let Some(window) = app.get_webview_window("main") {
-        let _ = window.center();
-        let _ = window.show();
-        let _ = window.set_focus();
-        let _ = app.emit("picker-shown", ());
-    }
+    present_picker(&app, "command");
 }
 
 /// Hides the picker window.
 #[tauri::command]
 fn hide_picker(app: AppHandle) {
-    if let Some(window) = app.get_webview_window("main") {
-        let _ = window.hide();
-    }
+    close_picker_window(&app);
 }
 
 /// Re-registers the global shortcut with a new binding.
@@ -98,16 +198,7 @@ fn update_shortcut(app: AppHandle, shortcut: String) {
             app.global_shortcut()
                 .on_shortcut(shortcut.as_str(), move |_app, _shortcut, event| {
                     if event.state == tauri_plugin_global_shortcut::ShortcutState::Pressed {
-                        if let Some(window) = handle.get_webview_window("main") {
-                            if window.is_visible().unwrap_or(false) {
-                                let _ = window.hide();
-                            } else {
-                                let _ = window.center();
-                                let _ = window.show();
-                                let _ = window.set_focus();
-                                let _ = handle.emit("picker-shown", ());
-                            }
-                        }
+                        present_picker(&handle, "shortcut-update");
                     }
                 });
 
@@ -135,16 +226,7 @@ fn register_wayland_shortcut(app: AppHandle, shortcut: &str) {
             "Toggle Emoji Nook",
             Some(&trigger),
             move || {
-                if let Some(window) = handle.get_webview_window("main") {
-                    if window.is_visible().unwrap_or(false) {
-                        let _ = window.hide();
-                    } else {
-                        let _ = window.center();
-                        let _ = window.show();
-                        let _ = window.set_focus();
-                        let _ = handle.emit("picker-shown", ());
-                    }
-                }
+                present_picker(&handle, "wayland-shortcut");
             },
         )
         .await
@@ -173,16 +255,7 @@ fn register_x11_shortcut(app: &AppHandle, shortcut: &str) {
         .global_shortcut()
         .on_shortcut(shortcut, move |_app, _shortcut, event| {
             if event.state == tauri_plugin_global_shortcut::ShortcutState::Pressed {
-                if let Some(window) = handle.get_webview_window("main") {
-                    if window.is_visible().unwrap_or(false) {
-                        let _ = window.hide();
-                    } else {
-                        let _ = window.center();
-                        let _ = window.show();
-                        let _ = window.set_focus();
-                        let _ = handle.emit("picker-shown", ());
-                    }
-                }
+                present_picker(&handle, "x11-shortcut");
             }
         });
 
@@ -207,14 +280,12 @@ fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
         .menu(&menu)
         .on_menu_event(move |app, event| match event.id().as_ref() {
             "show" => {
-                if let Some(window) = app.get_webview_window("main") {
-                    let _ = window.center();
-                    let _ = window.show();
-                    let _ = window.set_focus();
-                    let _ = app.emit("picker-shown", ());
-                }
+                present_picker(app, "tray");
             }
             "quit" => {
+                app.state::<LifecycleState>()
+                    .quit_requested
+                    .store(true, Ordering::SeqCst);
                 app.exit(0);
             }
             _ => {}
@@ -226,7 +297,9 @@ fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    let app = tauri::Builder::default()
+        .manage(LifecycleState::default())
+        .plugin(tauri_plugin_desktop_integration::init())
         .plugin(tauri_plugin_log::Builder::new().build())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_store::Builder::new().build())
@@ -257,8 +330,21 @@ pub fn run() {
             }
             Ok(())
         })
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application");
+
+    app.run(|app_handle, event| {
+        if let RunEvent::ExitRequested { api, .. } = event {
+            let quit_requested = app_handle
+                .state::<LifecycleState>()
+                .quit_requested
+                .load(Ordering::SeqCst);
+
+            if !quit_requested {
+                api.prevent_exit();
+            }
+        }
+    });
 }
 
 #[cfg(test)]

--- a/apps/emoji-picker/src-tauri/src/lib.rs
+++ b/apps/emoji-picker/src-tauri/src/lib.rs
@@ -135,6 +135,7 @@ fn present_picker(app: &AppHandle, source: &'static str) {
             let _ = window.set_focus();
             if !is_wayland() {
                 tauri_plugin_desktop_integration::request_activation_assist(
+                    &window,
                     source,
                     "Emoji Nook",
                     &label,

--- a/apps/emoji-picker/src-tauri/src/lib.rs
+++ b/apps/emoji-picker/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ use tauri::image::Image;
 use tauri::menu::{MenuBuilder, MenuItemBuilder};
 use tauri::tray::TrayIconBuilder;
 use tauri::{AppHandle, Manager, RunEvent, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
+use tauri_plugin_desktop_integration::DesktopIntegrationExt;
 use tauri_plugin_store::StoreExt;
 
 fn has_wayland_display(value: Option<&OsStr>) -> bool {
@@ -134,9 +135,7 @@ fn present_picker(app: &AppHandle, source: &'static str) {
             let _ = window.show();
             let _ = window.set_focus();
             if !is_wayland() {
-                tauri_plugin_desktop_integration::request_activation_assist(
-                    &window, source, &label,
-                );
+                app.request_desktop_activation_assist(&window, source, &label);
             }
             log_picker_focus_state(app, source, label.clone(), 75);
             log_picker_focus_state(app, source, label, 225);

--- a/apps/emoji-picker/src-tauri/src/lib.rs
+++ b/apps/emoji-picker/src-tauri/src/lib.rs
@@ -135,10 +135,7 @@ fn present_picker(app: &AppHandle, source: &'static str) {
             let _ = window.set_focus();
             if !is_wayland() {
                 tauri_plugin_desktop_integration::request_activation_assist(
-                    &window,
-                    source,
-                    "Emoji Nook",
-                    &label,
+                    &window, source, &label,
                 );
             }
             log_picker_focus_state(app, source, label.clone(), 75);

--- a/apps/emoji-picker/src-tauri/tauri.conf.json
+++ b/apps/emoji-picker/src-tauri/tauri.conf.json
@@ -10,21 +10,7 @@
 		"frontendDist": "../dist"
 	},
 	"app": {
-		"windows": [
-			{
-				"label": "main",
-				"title": "Emoji Nook",
-				"width": 370,
-				"height": 380,
-				"visible": false,
-				"decorations": false,
-				"transparent": true,
-				"alwaysOnTop": true,
-				"center": true,
-				"resizable": false,
-				"skipTaskbar": true
-			}
-		],
+		"windows": [],
 		"security": {
 			"csp": null
 		}

--- a/apps/emoji-picker/src/App.test.tsx
+++ b/apps/emoji-picker/src/App.test.tsx
@@ -64,6 +64,7 @@ describe('App', () => {
 
 		await waitFor(() =>
 			expect(invoke).toHaveBeenCalledWith('insert_emoji', {
+				closeOnSelect: true,
 				emoji: '😀',
 				label: 'grinning face',
 			}),

--- a/apps/emoji-picker/src/App.tsx
+++ b/apps/emoji-picker/src/App.tsx
@@ -27,17 +27,8 @@ function App() {
 			invoke('insert_emoji', {
 				emoji: selection.emoji,
 				label: selection.label,
+				closeOnSelect: settings.closeOnSelect,
 			}).catch((err) => console.error('insert_emoji IPC failed:', err));
-
-			// If close-on-select is disabled, re-show the picker after the
-			// injection has had time to paste into the target app. The Rust
-			// side hides the window and sleeps ~300ms before simulating
-			// Ctrl+V, so we wait long enough for that to land.
-			if (!settings.closeOnSelect) {
-				setTimeout(() => {
-					invoke('show_picker').catch(() => {});
-				}, 600);
-			}
 		},
 		[settings.closeOnSelect],
 	);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -130,6 +130,7 @@ graph LR
         subgraph Plugins
             Log["tauri-plugin-log"]
             Opener["tauri-plugin-opener"]
+            Desktop["tauri-plugin-desktop-integration"]
             XDG["tauri-plugin-xdg-portal"]
             GlobalSC["tauri-plugin-global-shortcut"]
             StorePlugin["tauri-plugin-store"]
@@ -144,6 +145,7 @@ graph LR
         end
 
         InsertEmoji --> Injection
+        Lib --> Desktop
     end
 
     subgraph PluginCrate["tauri-plugin-xdg-portal"]
@@ -246,19 +248,17 @@ graph LR
 
 > **Visual:** See the [animated theme detection diagram](images/theme_detection_flow.svg) for a visual overview of this pipeline.
 
-The picker adapts its appearance to the host desktop environment by reading theme properties via `xdg-desktop-portal` and mapping them to CSS custom properties. Theme info is re-fetched each time the picker is shown, catching changes that occurred while it was hidden.
+The picker adapts its appearance to the host desktop environment by reading theme properties via `xdg-desktop-portal` and mapping them to CSS custom properties. Because the picker window is recreated on each activation, theme info is fetched on mount for every fresh window.
 
 ```mermaid
 sequenceDiagram
     participant React as useTheme Hook
-    participant Event as Tauri Events
     participant IPC as Tauri IPC
     participant Plugin as xdg-portal Plugin
     participant DBus as xdg-desktop-portal
     participant DOM as Document Root
 
-    Event->>React: "picker-shown" event
-    React->>IPC: invoke("get_theme_info")
+    React->>IPC: getThemeInfo() on mount
     IPC->>Plugin: get_theme_info()
     Plugin->>DBus: Settings.color_scheme()
     Plugin->>DBus: Settings.accent_color()
@@ -353,38 +353,38 @@ flowchart TD
 
 > **Visual:** See the [animated window lifecycle diagram](images/window_lifecycle.svg) for an interactive state machine view.
 
-The picker window has a simple three-state lifecycle. It is created once at startup and never destroyed — only shown and hidden to avoid re-creation cost.
+The picker window has a simple three-state lifecycle. The app process stays resident in the tray, but the picker window itself is disposable and recreated for each activation under a fresh `picker-*` label.
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Hidden: App starts hidden
+    [*] --> Background: App starts in tray
 
-    Hidden --> Visible: Global shortcut pressed
-    Hidden --> Visible: Tray menu show picker
+    Background --> Visible: Global shortcut pressed
+    Background --> Visible: Tray menu show picker
 
-    Visible --> Hidden: Emoji selected (if closeOnSelect)
-    Visible --> Hidden: Esc pressed
-    Visible --> Hidden: Click outside (blur)
-    Visible --> Hidden: Shortcut pressed again
+    Visible --> Background: Emoji selected
+    Visible --> Background: Esc pressed
+    Visible --> Background: Click outside (blur)
+    Visible --> Background: New activation recreates picker window
 
     Visible --> Settings: Gear icon clicked
     Settings --> Visible: Save cancel or Esc
 
     note right of Settings
-        Blur-to-hide suppressed
+        Blur-to-close suppressed
         Native dropdowns trigger blur
     end note
 
-    Hidden --> [*]: Tray quit
+    Background --> [*]: Tray quit
 ```
 
 ### Window Configuration
 
-The picker window is configured as a frameless overlay:
+The picker window is configured as a frameless overlay template in Rust. The app starts without any picker window, and later activations create fresh `picker-*` windows with the same overlay properties:
 
 | Property      | Value     | Purpose                            |
 | ------------- | --------- | ---------------------------------- |
-| `visible`     | `false`   | Hidden on startup                  |
+| Startup       | none      | Tray-first process with no window  |
 | `decorations` | `false`   | Frameless                          |
 | `transparent` | `true`    | Rounded corners float over desktop |
 | `alwaysOnTop` | `true`    | Stays above other windows          |
@@ -437,13 +437,13 @@ graph LR
     style Breeze fill:#2980b9,color:#fff
 ```
 
-Theme info is re-fetched each time the picker is shown (via `picker-shown` event), catching changes that occurred between hides. The `color-scheme` CSS property is set on the document root so native form controls (selects, checkboxes) match the detected theme.
+Theme info is fetched whenever a fresh picker window mounts. The `color-scheme` CSS property is set on the document root so native form controls (selects, checkboxes) match the detected theme.
 
 ## System Tray
 
 The app provides a system tray icon with a context menu:
 
-- **Show Picker** — opens the overlay (centres, shows, focuses)
+- **Show Picker** — recreates and focuses a fresh picker window
 - **Quit** — exits the application
 
 The tray uses the default app icon and the tooltip "Emoji Nook". The tray provides a fallback for showing the picker when global shortcuts are unavailable (e.g. portal permission denied on Wayland).
@@ -503,6 +503,7 @@ emoji-nook/
 | Settings        | tauri-plugin-store                                        | Persistent JSON key-value store         |
 | Autostart       | tauri-plugin-autostart                                    | XDG autostart desktop file management   |
 | Shortcuts (X11) | tauri-plugin-global-shortcut                              | X11 global shortcut registration        |
+| Activation      | tauri-plugin-desktop-integration                          | X11 window activation assist            |
 | Logging         | tauri-plugin-log                                          | Structured logging with console bridge  |
 
 ### Runtime Dependencies

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -121,6 +121,8 @@ graph TD
 
 The Rust backend manages the application lifecycle, system tray, shortcut registration, and emoji injection. It delegates Linux-specific portal operations to the xdg-portal plugin and X11 activation quirks to the desktop-integration plugin.
 
+Unlike the xdg-portal plugin, the desktop-integration plugin is backend-only today. It keeps a standard Tauri plugin scaffold for permissions and future growth, but its current API is used directly from Rust through an extension trait rather than frontend `invoke(...)` commands.
+
 ```mermaid
 graph LR
     subgraph AppCrate["emoji-picker crate"]
@@ -169,8 +171,11 @@ graph LR
 
     subgraph DesktopPlugin["tauri-plugin-desktop-integration"]
         DesktopLib["lib.rs — Activation helpers"]
+        DesktopBuild["build.rs — Plugin metadata"]
+        DesktopPerms["permissions/default.toml"]
+        DesktopGuest["guest-js/ — Future guest bindings"]
         DesktopLib --> GTK["gtk_window() / present_with_time()"]
-        DesktopLib --> X11["gdkx11 user-time + xid fallback"]
+        DesktopLib --> X11["gdkx11 user-time metadata"]
     end
 
     XDG --> PluginLib
@@ -484,8 +489,12 @@ emoji-nook/
 │           └── capabilities/              # Tauri v2 permission grants
 ├── plugins/
 │   ├── desktop-integration/
-│   │   └── src/                    # Rust plugin
-│   │       └── lib.rs              # X11 activation + user-time helpers
+│   │   ├── src/                    # Rust plugin
+│   │   │   └── lib.rs              # X11 activation + user-time helpers
+│   │   ├── guest-js/               # Guest bindings placeholder
+│   │   ├── permissions/            # Plugin permission definitions
+│   │   ├── build.rs                # Plugin metadata generation
+│   │   └── README.md               # Plugin-specific notes
 │   └── xdg-portal/
 │       ├── src/                    # Rust plugin
 │       │   ├── lib.rs                     # Plugin registration

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,11 +46,13 @@ graph TB
         Compositor[Wayland / X11]
         CB[Clipboard — arboard]
         Tools[ydotool / wtype / xdotool]
+        WMHints[_NET_WM_USER_TIME / X11 activation]
     end
 
     KB --> SC
     SC --> WM
     WM --> Picker
+    WM --> WMHints
     Picker --> INJ
     INJ --> CB
     CB --> Tools
@@ -117,7 +119,7 @@ graph TD
 
 ### Backend (Rust / Tauri v2)
 
-The Rust backend manages the application lifecycle, system tray, shortcut registration, and emoji injection. It delegates Linux-specific portal operations to the xdg-portal plugin.
+The Rust backend manages the application lifecycle, system tray, shortcut registration, and emoji injection. It delegates Linux-specific portal operations to the xdg-portal plugin and X11 activation quirks to the desktop-integration plugin.
 
 ```mermaid
 graph LR
@@ -148,7 +150,7 @@ graph LR
         Lib --> Desktop
     end
 
-    subgraph PluginCrate["tauri-plugin-xdg-portal"]
+    subgraph PortalPlugin["tauri-plugin-xdg-portal"]
         PluginLib["lib.rs — Plugin registration"]
         PluginLib --> Cmds["commands.rs"]
         PluginLib --> Linux["linux.rs"]
@@ -165,7 +167,14 @@ graph LR
         Cmds --> PortalCommands
     end
 
+    subgraph DesktopPlugin["tauri-plugin-desktop-integration"]
+        DesktopLib["lib.rs — Activation helpers"]
+        DesktopLib --> GTK["gtk_window() / present_with_time()"]
+        DesktopLib --> X11["gdkx11 user-time + xid fallback"]
+    end
+
     XDG --> PluginLib
+    Desktop --> DesktopLib
 ```
 
 ## Data Flow
@@ -393,6 +402,8 @@ The picker window is configured as a frameless overlay template in Rust. The app
 | `skipTaskbar` | `true`    | Background process, tray-only      |
 | Size          | 370 x 380 | Compact picker dimensions          |
 
+On X11, each fresh picker window is also handed to the desktop-integration plugin. The plugin asks GTK to `present_with_time(...)`, stamps `_NET_WM_USER_TIME` via `gdkx11` when possible, and keeps an `xdotool` activation fallback available for Cinnamon/Muffin focus-policy edge cases.
+
 ## Native Theming
 
 > **Visual:** See the [animated theme detection diagram](images/theme_detection_flow.svg) for a visual overview of this pipeline.
@@ -472,6 +483,9 @@ emoji-nook/
 │           │   └── injection.rs           # Clipboard shuffle
 │           └── capabilities/              # Tauri v2 permission grants
 ├── plugins/
+│   ├── desktop-integration/
+│   │   └── src/                    # Rust plugin
+│   │       └── lib.rs              # X11 activation + user-time helpers
 │   └── xdg-portal/
 │       ├── src/                    # Rust plugin
 │       │   ├── lib.rs                     # Plugin registration
@@ -503,7 +517,7 @@ emoji-nook/
 | Settings        | tauri-plugin-store                                        | Persistent JSON key-value store         |
 | Autostart       | tauri-plugin-autostart                                    | XDG autostart desktop file management   |
 | Shortcuts (X11) | tauri-plugin-global-shortcut                              | X11 global shortcut registration        |
-| Activation      | tauri-plugin-desktop-integration                          | X11 window activation assist            |
+| Activation      | tauri-plugin-desktop-integration                          | X11 user-time + activation assist       |
 | Logging         | tauri-plugin-log                                          | Structured logging with console bridge  |
 
 ### Runtime Dependencies

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -402,7 +402,7 @@ The picker window is configured as a frameless overlay template in Rust. The app
 | `skipTaskbar` | `true`    | Background process, tray-only      |
 | Size          | 370 x 380 | Compact picker dimensions          |
 
-On X11, each fresh picker window is also handed to the desktop-integration plugin. The plugin asks GTK to `present_with_time(...)`, stamps `_NET_WM_USER_TIME` via `gdkx11` when possible, and keeps an `xdotool` activation fallback available for Cinnamon/Muffin focus-policy edge cases.
+On X11, each fresh picker window is also handed to the desktop-integration plugin. The plugin asks GTK to `present_with_time(...)` and stamps `_NET_WM_USER_TIME` via `gdkx11` so Cinnamon/Muffin receives a native activation timestamp for the fresh picker window.
 
 ## Native Theming
 
@@ -517,7 +517,7 @@ emoji-nook/
 | Settings        | tauri-plugin-store                                        | Persistent JSON key-value store         |
 | Autostart       | tauri-plugin-autostart                                    | XDG autostart desktop file management   |
 | Shortcuts (X11) | tauri-plugin-global-shortcut                              | X11 global shortcut registration        |
-| Activation      | tauri-plugin-desktop-integration                          | X11 user-time + activation assist       |
+| Activation      | tauri-plugin-desktop-integration                          | Native X11 user-time activation         |
 | Logging         | tauri-plugin-log                                          | Structured logging with console bridge  |
 
 ### Runtime Dependencies

--- a/plugins/desktop-integration/Cargo.toml
+++ b/plugins/desktop-integration/Cargo.toml
@@ -5,6 +5,14 @@ description = "Desktop activation helpers for Emoji Nook"
 authors = ["Liminal HQ, Scott Morris"]
 license.workspace = true
 edition.workspace = true
+homepage = "https://github.com/liminal-hq/emoji-nook"
+repository = "https://github.com/liminal-hq/emoji-nook"
+build = "build.rs"
+links = "tauri-plugin-desktop-integration"
+
+[lib]
+name = "tauri_plugin_desktop_integration"
+crate-type = ["rlib", "cdylib"]
 
 [dependencies]
 gdk = "0.18"
@@ -12,3 +20,6 @@ gdkx11 = "0.18"
 gtk = "0.18"
 log = { workspace = true }
 tauri = { workspace = true }
+
+[build-dependencies]
+tauri-plugin = { version = "2", features = ["build"] }

--- a/plugins/desktop-integration/Cargo.toml
+++ b/plugins/desktop-integration/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tauri-plugin-desktop-integration"
+version = "0.1.0"
+description = "Desktop activation helpers for Emoji Nook"
+authors = ["Liminal HQ, Scott Morris"]
+license.workspace = true
+edition.workspace = true
+
+[dependencies]
+log = { workspace = true }
+tauri = { workspace = true }

--- a/plugins/desktop-integration/Cargo.toml
+++ b/plugins/desktop-integration/Cargo.toml
@@ -7,5 +7,8 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
+gdk = "0.18"
+gdkx11 = "0.18"
+gtk = "0.18"
 log = { workspace = true }
 tauri = { workspace = true }

--- a/plugins/desktop-integration/README.md
+++ b/plugins/desktop-integration/README.md
@@ -1,0 +1,24 @@
+# tauri-plugin-desktop-integration
+
+`tauri-plugin-desktop-integration` is Emoji Nook's small platform-integration plugin for desktop activation quirks that do not belong in the app crate.
+
+Today it is focused on Linux X11 activation under Cinnamon/Muffin:
+
+- It requests native GTK window presentation with a real event timestamp.
+- It stamps `_NET_WM_USER_TIME` through `gdkx11` so fresh picker windows look like legitimate user-driven activations.
+- It keeps that behaviour isolated from the app's picker lifecycle logic.
+
+## Layout
+
+- `src/lib.rs`: backend integration hooks used by the Tauri app.
+- `build.rs`: Tauri plugin metadata and permission manifest generation.
+- `permissions/default.toml`: default permission set for the plugin.
+- `guest-js/`: guest-side package placeholder for future frontend-facing helpers.
+
+## Commands and permissions
+
+The plugin does not expose any frontend-invokable commands yet. It is a backend-only integration plugin, so its default permission set is intentionally empty for now.
+
+The Rust side is exposed as a direct extension trait instead of an invoke command surface. That matches how many Tauri plugins expose backend-only helpers while still keeping the normal plugin metadata, permissions, and guest package structure in place.
+
+The plugin still carries normal Tauri plugin scaffolding so it can grow cleanly if we later add frontend-facing APIs or platform-specific helpers.

--- a/plugins/desktop-integration/build.rs
+++ b/plugins/desktop-integration/build.rs
@@ -1,0 +1,10 @@
+// Generates plugin metadata and permission manifests for desktop integration
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+const COMMANDS: &[&str] = &[];
+
+fn main() {
+    tauri_plugin::Builder::new(COMMANDS).build();
+}

--- a/plugins/desktop-integration/guest-js/package.json
+++ b/plugins/desktop-integration/guest-js/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "tauri-plugin-desktop-integration",
+	"version": "0.1.0",
+	"description": "Guest JavaScript bindings for the Emoji Nook desktop-integration plugin",
+	"license": "(Apache-2.0 OR MIT)",
+	"type": "module",
+	"main": "src/index.ts",
+	"types": "src/index.ts"
+}

--- a/plugins/desktop-integration/guest-js/src/index.ts
+++ b/plugins/desktop-integration/guest-js/src/index.ts
@@ -1,0 +1,16 @@
+// Exposes guest-side metadata for the desktop-integration plugin package
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+export const pluginName = 'desktop-integration';
+
+/**
+ * The desktop-integration plugin is currently backend-only.
+ *
+ * The guest package exists so the workspace keeps a standard Tauri plugin
+ * layout and has a stable place for future guest-side helpers.
+ */
+export const desktopIntegration = Object.freeze({
+	pluginName,
+});

--- a/plugins/desktop-integration/permissions/autogenerated/reference.md
+++ b/plugins/desktop-integration/permissions/autogenerated/reference.md
@@ -1,0 +1,13 @@
+## Default Permission
+
+Default permissions for the desktop-integration plugin
+
+## Permission Table
+
+<table>
+<tr>
+<th>Identifier</th>
+<th>Description</th>
+</tr>
+
+</table>

--- a/plugins/desktop-integration/permissions/default.toml
+++ b/plugins/desktop-integration/permissions/default.toml
@@ -1,0 +1,3 @@
+[default]
+description = "Default permissions for the desktop-integration plugin"
+permissions = []

--- a/plugins/desktop-integration/permissions/schemas/schema.json
+++ b/plugins/desktop-integration/permissions/schemas/schema.json
@@ -1,0 +1,306 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PermissionFile",
+  "description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
+  "type": "object",
+  "properties": {
+    "default": {
+      "description": "The default permission set for the plugin",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DefaultPermission"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
+    },
+    "permission": {
+      "description": "A list of inlined permissions",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Permission"
+      }
+    }
+  },
+  "definitions": {
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+      "type": "object",
+      "required": [
+        "permissions"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "platforms": {
+          "description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "Commands": {
+      "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Allowed command.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "description": "Denied command, which takes priority.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    },
+    "PermissionKind": {
+      "type": "string",
+      "oneOf": [
+        {
+          "description": "Default permissions for the desktop-integration plugin",
+          "type": "string",
+          "const": "default",
+          "markdownDescription": "Default permissions for the desktop-integration plugin"
+        }
+      ]
+    }
+  }
+}

--- a/plugins/desktop-integration/permissions/schemas/schema.json
+++ b/plugins/desktop-integration/permissions/schemas/schema.json
@@ -1,306 +1,267 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "PermissionFile",
-  "description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
-  "type": "object",
-  "properties": {
-    "default": {
-      "description": "The default permission set for the plugin",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/DefaultPermission"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "set": {
-      "description": "A list of permissions sets defined",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/PermissionSet"
-      }
-    },
-    "permission": {
-      "description": "A list of inlined permissions",
-      "default": [],
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/Permission"
-      }
-    }
-  },
-  "definitions": {
-    "DefaultPermission": {
-      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
-      "type": "object",
-      "required": [
-        "permissions"
-      ],
-      "properties": {
-        "version": {
-          "description": "The version of the permission.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 1.0
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "permissions": {
-          "description": "All permissions this set contains.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "PermissionSet": {
-      "description": "A set of direct permissions grouped together under a new name.",
-      "type": "object",
-      "required": [
-        "description",
-        "identifier",
-        "permissions"
-      ],
-      "properties": {
-        "identifier": {
-          "description": "A unique identifier for the permission.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": "string"
-        },
-        "permissions": {
-          "description": "All permissions this set contains.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/PermissionKind"
-          }
-        }
-      }
-    },
-    "Permission": {
-      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
-      "type": "object",
-      "required": [
-        "identifier"
-      ],
-      "properties": {
-        "version": {
-          "description": "The version of the permission.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 1.0
-        },
-        "identifier": {
-          "description": "A unique identifier for the permission.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "commands": {
-          "description": "Allowed or denied commands when using this permission.",
-          "default": {
-            "allow": [],
-            "deny": []
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/Commands"
-            }
-          ]
-        },
-        "scope": {
-          "description": "Allowed or denied scoped when using this permission.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Scopes"
-            }
-          ]
-        },
-        "platforms": {
-          "description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/Target"
-          }
-        }
-      }
-    },
-    "Commands": {
-      "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
-      "type": "object",
-      "properties": {
-        "allow": {
-          "description": "Allowed command.",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "deny": {
-          "description": "Denied command, which takes priority.",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "Scopes": {
-      "description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
-      "type": "object",
-      "properties": {
-        "allow": {
-          "description": "Data that defines what is allowed by the scope.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/Value"
-          }
-        },
-        "deny": {
-          "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/Value"
-          }
-        }
-      }
-    },
-    "Value": {
-      "description": "All supported ACL values.",
-      "anyOf": [
-        {
-          "description": "Represents a null JSON value.",
-          "type": "null"
-        },
-        {
-          "description": "Represents a [`bool`].",
-          "type": "boolean"
-        },
-        {
-          "description": "Represents a valid ACL [`Number`].",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Number"
-            }
-          ]
-        },
-        {
-          "description": "Represents a [`String`].",
-          "type": "string"
-        },
-        {
-          "description": "Represents a list of other [`Value`]s.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Value"
-          }
-        },
-        {
-          "description": "Represents a map of [`String`] keys to [`Value`]s.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/Value"
-          }
-        }
-      ]
-    },
-    "Number": {
-      "description": "A valid ACL number.",
-      "anyOf": [
-        {
-          "description": "Represents an [`i64`].",
-          "type": "integer",
-          "format": "int64"
-        },
-        {
-          "description": "Represents a [`f64`].",
-          "type": "number",
-          "format": "double"
-        }
-      ]
-    },
-    "Target": {
-      "description": "Platform target.",
-      "oneOf": [
-        {
-          "description": "MacOS.",
-          "type": "string",
-          "enum": [
-            "macOS"
-          ]
-        },
-        {
-          "description": "Windows.",
-          "type": "string",
-          "enum": [
-            "windows"
-          ]
-        },
-        {
-          "description": "Linux.",
-          "type": "string",
-          "enum": [
-            "linux"
-          ]
-        },
-        {
-          "description": "Android.",
-          "type": "string",
-          "enum": [
-            "android"
-          ]
-        },
-        {
-          "description": "iOS.",
-          "type": "string",
-          "enum": [
-            "iOS"
-          ]
-        }
-      ]
-    },
-    "PermissionKind": {
-      "type": "string",
-      "oneOf": [
-        {
-          "description": "Default permissions for the desktop-integration plugin",
-          "type": "string",
-          "const": "default",
-          "markdownDescription": "Default permissions for the desktop-integration plugin"
-        }
-      ]
-    }
-  }
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"title": "PermissionFile",
+	"description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
+	"type": "object",
+	"properties": {
+		"default": {
+			"description": "The default permission set for the plugin",
+			"anyOf": [
+				{
+					"$ref": "#/definitions/DefaultPermission"
+				},
+				{
+					"type": "null"
+				}
+			]
+		},
+		"set": {
+			"description": "A list of permissions sets defined",
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/PermissionSet"
+			}
+		},
+		"permission": {
+			"description": "A list of inlined permissions",
+			"default": [],
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/Permission"
+			}
+		}
+	},
+	"definitions": {
+		"DefaultPermission": {
+			"description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+			"type": "object",
+			"required": ["permissions"],
+			"properties": {
+				"version": {
+					"description": "The version of the permission.",
+					"type": ["integer", "null"],
+					"format": "uint64",
+					"minimum": 1.0
+				},
+				"description": {
+					"description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+					"type": ["string", "null"]
+				},
+				"permissions": {
+					"description": "All permissions this set contains.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		"PermissionSet": {
+			"description": "A set of direct permissions grouped together under a new name.",
+			"type": "object",
+			"required": ["description", "identifier", "permissions"],
+			"properties": {
+				"identifier": {
+					"description": "A unique identifier for the permission.",
+					"type": "string"
+				},
+				"description": {
+					"description": "Human-readable description of what the permission does.",
+					"type": "string"
+				},
+				"permissions": {
+					"description": "All permissions this set contains.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/PermissionKind"
+					}
+				}
+			}
+		},
+		"Permission": {
+			"description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+			"type": "object",
+			"required": ["identifier"],
+			"properties": {
+				"version": {
+					"description": "The version of the permission.",
+					"type": ["integer", "null"],
+					"format": "uint64",
+					"minimum": 1.0
+				},
+				"identifier": {
+					"description": "A unique identifier for the permission.",
+					"type": "string"
+				},
+				"description": {
+					"description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+					"type": ["string", "null"]
+				},
+				"commands": {
+					"description": "Allowed or denied commands when using this permission.",
+					"default": {
+						"allow": [],
+						"deny": []
+					},
+					"allOf": [
+						{
+							"$ref": "#/definitions/Commands"
+						}
+					]
+				},
+				"scope": {
+					"description": "Allowed or denied scoped when using this permission.",
+					"allOf": [
+						{
+							"$ref": "#/definitions/Scopes"
+						}
+					]
+				},
+				"platforms": {
+					"description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
+					"type": ["array", "null"],
+					"items": {
+						"$ref": "#/definitions/Target"
+					}
+				}
+			}
+		},
+		"Commands": {
+			"description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
+			"type": "object",
+			"properties": {
+				"allow": {
+					"description": "Allowed command.",
+					"default": [],
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"deny": {
+					"description": "Denied command, which takes priority.",
+					"default": [],
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		"Scopes": {
+			"description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
+			"type": "object",
+			"properties": {
+				"allow": {
+					"description": "Data that defines what is allowed by the scope.",
+					"type": ["array", "null"],
+					"items": {
+						"$ref": "#/definitions/Value"
+					}
+				},
+				"deny": {
+					"description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+					"type": ["array", "null"],
+					"items": {
+						"$ref": "#/definitions/Value"
+					}
+				}
+			}
+		},
+		"Value": {
+			"description": "All supported ACL values.",
+			"anyOf": [
+				{
+					"description": "Represents a null JSON value.",
+					"type": "null"
+				},
+				{
+					"description": "Represents a [`bool`].",
+					"type": "boolean"
+				},
+				{
+					"description": "Represents a valid ACL [`Number`].",
+					"allOf": [
+						{
+							"$ref": "#/definitions/Number"
+						}
+					]
+				},
+				{
+					"description": "Represents a [`String`].",
+					"type": "string"
+				},
+				{
+					"description": "Represents a list of other [`Value`]s.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/Value"
+					}
+				},
+				{
+					"description": "Represents a map of [`String`] keys to [`Value`]s.",
+					"type": "object",
+					"additionalProperties": {
+						"$ref": "#/definitions/Value"
+					}
+				}
+			]
+		},
+		"Number": {
+			"description": "A valid ACL number.",
+			"anyOf": [
+				{
+					"description": "Represents an [`i64`].",
+					"type": "integer",
+					"format": "int64"
+				},
+				{
+					"description": "Represents a [`f64`].",
+					"type": "number",
+					"format": "double"
+				}
+			]
+		},
+		"Target": {
+			"description": "Platform target.",
+			"oneOf": [
+				{
+					"description": "MacOS.",
+					"type": "string",
+					"enum": ["macOS"]
+				},
+				{
+					"description": "Windows.",
+					"type": "string",
+					"enum": ["windows"]
+				},
+				{
+					"description": "Linux.",
+					"type": "string",
+					"enum": ["linux"]
+				},
+				{
+					"description": "Android.",
+					"type": "string",
+					"enum": ["android"]
+				},
+				{
+					"description": "iOS.",
+					"type": "string",
+					"enum": ["iOS"]
+				}
+			]
+		},
+		"PermissionKind": {
+			"type": "string",
+			"oneOf": [
+				{
+					"description": "Default permissions for the desktop-integration plugin",
+					"type": "string",
+					"const": "default",
+					"markdownDescription": "Default permissions for the desktop-integration plugin"
+				}
+			]
+		}
+	}
 }

--- a/plugins/desktop-integration/src/lib.rs
+++ b/plugins/desktop-integration/src/lib.rs
@@ -3,52 +3,134 @@
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use gtk::glib::object::Cast;
+use gtk::prelude::*;
 use log::info;
 use std::process::Command;
 use tauri::{
     plugin::{Builder, TauriPlugin},
-    Runtime,
+    Runtime, WebviewWindow,
 };
+
+use gdkx11::functions::x11_get_server_time;
 
 pub fn init<R: Runtime>() -> TauriPlugin<R> {
     Builder::new("desktop-integration").build()
 }
 
-pub fn request_activation_assist(source: &'static str, title: &str, label: &str) {
-    let title = title.to_string();
-    let label = label.to_string();
+fn request_x11_user_time<R: Runtime>(
+    window: &WebviewWindow<R>,
+    source: &'static str,
+    label: &str,
+) -> Option<u64> {
+    let gtk_window = match window.gtk_window() {
+        Ok(window) => window,
+        Err(error) => {
+            info!("native X11 activation unavailable for {source} label={label}: {error}");
+            return None;
+        }
+    };
 
+    let mut timestamp = gtk::current_event_time();
+    let mut xid = None;
+
+    if let Some(gdk_window) = gtk_window.window() {
+        if let Ok(x11_window) = gdk_window.downcast::<gdkx11::X11Window>() {
+            xid = Some(x11_window.xid() as u64);
+
+            let server_time = x11_get_server_time(&x11_window);
+            if server_time != 0 {
+                timestamp = server_time;
+                x11_window.set_user_time(server_time);
+            }
+        }
+    }
+
+    if timestamp == 0 {
+        if let Ok(x11_display) = gtk_window.display().downcast::<gdkx11::X11Display>() {
+            let display_user_time = x11_display.user_time();
+            if display_user_time != 0 {
+                timestamp = display_user_time;
+            }
+        }
+    }
+
+    gtk_window.present_with_time(timestamp);
+    info!(
+        "native X11 activation requested for {source} label={label} timestamp={timestamp} xid={:?}",
+        xid
+    );
+
+    xid
+}
+
+fn spawn_xdotool_fallback(source: &'static str, title: String, label: String, xid: Option<u64>) {
     std::thread::spawn(move || {
         for delay_ms in [100_u64, 250_u64] {
             std::thread::sleep(std::time::Duration::from_millis(delay_ms));
 
-            match Command::new("xdotool")
-                .args(["search", "--name", &format!("^{title}$"), "windowactivate"])
-                .output()
-            {
+            let result = if let Some(xid) = xid {
+                Command::new("xdotool")
+                    .args(["windowactivate", &xid.to_string()])
+                    .output()
+            } else {
+                Command::new("xdotool")
+                    .args(["search", "--name", &format!("^{title}$"), "windowactivate"])
+                    .output()
+            };
+
+            match result {
                 Ok(output) if output.status.success() => {
                     info!(
-                        "X11 activation assist succeeded for {source} label={label} delay={}ms",
-                        delay_ms
+                        "X11 activation assist succeeded for {source} label={label} delay={}ms xid={:?}",
+                        delay_ms, xid
                     );
                     return;
                 }
                 Ok(output) => {
                     let stderr = String::from_utf8_lossy(&output.stderr);
                     info!(
-                        "X11 activation assist failed for {source} label={label} delay={}ms: {}",
+                        "X11 activation assist failed for {source} label={label} delay={}ms xid={:?}: {}",
                         delay_ms,
+                        xid,
                         stderr.trim()
                     );
                 }
                 Err(error) => {
                     info!(
-                        "X11 activation assist unavailable for {source} label={label} delay={}ms: {error}",
-                        delay_ms
+                        "X11 activation assist unavailable for {source} label={label} delay={}ms xid={:?}: {error}",
+                        delay_ms, xid
                     );
                     return;
                 }
             }
         }
     });
+}
+
+pub fn request_activation_assist<R: Runtime>(
+    window: &WebviewWindow<R>,
+    source: &'static str,
+    title: &str,
+    label: &str,
+) {
+    let title = title.to_string();
+    let label = label.to_string();
+    let window = window.clone();
+    let fallback_title = title.clone();
+    let fallback_label = label.clone();
+    let fallback_window = window.clone();
+
+    match fallback_window.run_on_main_thread(move || {
+        let xid = request_x11_user_time(&window, source, &label);
+        spawn_xdotool_fallback(source, title, label, xid);
+    }) {
+        Ok(()) => {}
+        Err(error) => {
+            info!(
+                "failed to schedule native X11 activation for {source} label={fallback_label}: {error}"
+            );
+            spawn_xdotool_fallback(source, fallback_title, fallback_label, None);
+        }
+    }
 }

--- a/plugins/desktop-integration/src/lib.rs
+++ b/plugins/desktop-integration/src/lib.rs
@@ -6,7 +6,6 @@
 use gtk::glib::object::Cast;
 use gtk::prelude::*;
 use log::info;
-use std::process::Command;
 use tauri::{
     plugin::{Builder, TauriPlugin},
     Runtime, WebviewWindow,
@@ -18,16 +17,12 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
     Builder::new("desktop-integration").build()
 }
 
-fn request_x11_user_time<R: Runtime>(
-    window: &WebviewWindow<R>,
-    source: &'static str,
-    label: &str,
-) -> Option<u64> {
+fn request_x11_user_time<R: Runtime>(window: &WebviewWindow<R>, source: &'static str, label: &str) {
     let gtk_window = match window.gtk_window() {
         Ok(window) => window,
         Err(error) => {
             info!("native X11 activation unavailable for {source} label={label}: {error}");
-            return None;
+            return;
         }
     };
 
@@ -60,77 +55,26 @@ fn request_x11_user_time<R: Runtime>(
         "native X11 activation requested for {source} label={label} timestamp={timestamp} xid={:?}",
         xid
     );
-
-    xid
-}
-
-fn spawn_xdotool_fallback(source: &'static str, title: String, label: String, xid: Option<u64>) {
-    std::thread::spawn(move || {
-        for delay_ms in [100_u64, 250_u64] {
-            std::thread::sleep(std::time::Duration::from_millis(delay_ms));
-
-            let result = if let Some(xid) = xid {
-                Command::new("xdotool")
-                    .args(["windowactivate", &xid.to_string()])
-                    .output()
-            } else {
-                Command::new("xdotool")
-                    .args(["search", "--name", &format!("^{title}$"), "windowactivate"])
-                    .output()
-            };
-
-            match result {
-                Ok(output) if output.status.success() => {
-                    info!(
-                        "X11 activation assist succeeded for {source} label={label} delay={}ms xid={:?}",
-                        delay_ms, xid
-                    );
-                    return;
-                }
-                Ok(output) => {
-                    let stderr = String::from_utf8_lossy(&output.stderr);
-                    info!(
-                        "X11 activation assist failed for {source} label={label} delay={}ms xid={:?}: {}",
-                        delay_ms,
-                        xid,
-                        stderr.trim()
-                    );
-                }
-                Err(error) => {
-                    info!(
-                        "X11 activation assist unavailable for {source} label={label} delay={}ms xid={:?}: {error}",
-                        delay_ms, xid
-                    );
-                    return;
-                }
-            }
-        }
-    });
 }
 
 pub fn request_activation_assist<R: Runtime>(
     window: &WebviewWindow<R>,
     source: &'static str,
-    title: &str,
     label: &str,
 ) {
-    let title = title.to_string();
     let label = label.to_string();
     let window = window.clone();
-    let fallback_title = title.clone();
+    let main_thread_window = window.clone();
     let fallback_label = label.clone();
-    let fallback_window = window.clone();
 
-    match fallback_window.run_on_main_thread(move || {
-        let xid = request_x11_user_time(&window, source, &label);
-        spawn_xdotool_fallback(source, title, label, xid);
+    match main_thread_window.run_on_main_thread(move || {
+        request_x11_user_time(&window, source, &label);
     }) {
         Ok(()) => {}
         Err(error) => {
             info!(
                 "failed to schedule native X11 activation for {source} label={fallback_label}: {error}"
             );
-            spawn_xdotool_fallback(source, fallback_title, fallback_label, None);
         }
     }
 }

--- a/plugins/desktop-integration/src/lib.rs
+++ b/plugins/desktop-integration/src/lib.rs
@@ -1,0 +1,54 @@
+// Provides desktop-integration helpers for window activation on Linux
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use log::info;
+use std::process::Command;
+use tauri::{
+    plugin::{Builder, TauriPlugin},
+    Runtime,
+};
+
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+    Builder::new("desktop-integration").build()
+}
+
+pub fn request_activation_assist(source: &'static str, title: &str, label: &str) {
+    let title = title.to_string();
+    let label = label.to_string();
+
+    std::thread::spawn(move || {
+        for delay_ms in [100_u64, 250_u64] {
+            std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+
+            match Command::new("xdotool")
+                .args(["search", "--name", &format!("^{title}$"), "windowactivate"])
+                .output()
+            {
+                Ok(output) if output.status.success() => {
+                    info!(
+                        "X11 activation assist succeeded for {source} label={label} delay={}ms",
+                        delay_ms
+                    );
+                    return;
+                }
+                Ok(output) => {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    info!(
+                        "X11 activation assist failed for {source} label={label} delay={}ms: {}",
+                        delay_ms,
+                        stderr.trim()
+                    );
+                }
+                Err(error) => {
+                    info!(
+                        "X11 activation assist unavailable for {source} label={label} delay={}ms: {error}",
+                        delay_ms
+                    );
+                    return;
+                }
+            }
+        }
+    });
+}

--- a/plugins/desktop-integration/src/lib.rs
+++ b/plugins/desktop-integration/src/lib.rs
@@ -13,6 +13,15 @@ use tauri::{
 
 use gdkx11::functions::x11_get_server_time;
 
+pub trait DesktopIntegrationExt<R: Runtime> {
+    fn request_desktop_activation_assist(
+        &self,
+        window: &WebviewWindow<R>,
+        source: &'static str,
+        label: &str,
+    );
+}
+
 pub fn init<R: Runtime>() -> TauriPlugin<R> {
     Builder::new("desktop-integration").build()
 }
@@ -57,24 +66,27 @@ fn request_x11_user_time<R: Runtime>(window: &WebviewWindow<R>, source: &'static
     );
 }
 
-pub fn request_activation_assist<R: Runtime>(
-    window: &WebviewWindow<R>,
-    source: &'static str,
-    label: &str,
-) {
-    let label = label.to_string();
-    let window = window.clone();
-    let main_thread_window = window.clone();
-    let fallback_label = label.clone();
+impl<R: Runtime, T> DesktopIntegrationExt<R> for T {
+    fn request_desktop_activation_assist(
+        &self,
+        window: &WebviewWindow<R>,
+        source: &'static str,
+        label: &str,
+    ) {
+        let label = label.to_string();
+        let window = window.clone();
+        let main_thread_window = window.clone();
+        let fallback_label = label.clone();
 
-    match main_thread_window.run_on_main_thread(move || {
-        request_x11_user_time(&window, source, &label);
-    }) {
-        Ok(()) => {}
-        Err(error) => {
-            info!(
-                "failed to schedule native X11 activation for {source} label={fallback_label}: {error}"
-            );
+        match main_thread_window.run_on_main_thread(move || {
+            request_x11_user_time(&window, source, &label);
+        }) {
+            Ok(()) => {}
+            Err(error) => {
+                info!(
+                    "failed to schedule native X11 activation for {source} label={fallback_label}: {error}"
+                );
+            }
         }
     }
 }

--- a/plugins/desktop-integration/src/lib.rs
+++ b/plugins/desktop-integration/src/lib.rs
@@ -31,7 +31,7 @@ fn request_x11_user_time<R: Runtime>(window: &WebviewWindow<R>, source: &'static
 
     if let Some(gdk_window) = gtk_window.window() {
         if let Ok(x11_window) = gdk_window.downcast::<gdkx11::X11Window>() {
-            xid = Some(x11_window.xid() as u64);
+            xid = Some(x11_window.xid());
 
             let server_time = x11_get_server_time(&x11_window);
             if server_time != 0 {


### PR DESCRIPTION
## Summary

- **X11 focus reliability:** Stamp fresh picker windows with native GTK/X11 user-time metadata and present them with that timestamp so Cinnamon/Muffin treats repeated shortcut activations as legitimate focus handoffs.
- **Window lifecycle:** Keep the tray-resident, recreate-on-open picker lifecycle so each activation gets a fresh `picker-*` window and clean UI state.
- **Cleanup:** Remove the temporary `xdotool` window-activation fallback after confirming the native `_NET_WM_USER_TIME` path is sufficient on Cinnamon/X11.
- **Documentation:** Update the picker README and architecture notes to describe the final native activation flow.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `docker run --rm -v /home/scott/source/liminal-hq/emoji-nook:/workspaces/emoji-nook -w /workspaces/emoji-nook ghcr.io/liminal-hq/tauri-dev-desktop:latest bash -lc 'cargo fmt --all --check && cargo build --workspace'`
- [x] Manual test on Linux Mint Cinnamon/X11: open the picker repeatedly with the global shortcut and confirm focus lands in the picker each time
- [x] Manual test on Linux Mint Cinnamon/X11: select an emoji and confirm paste injection still works through the existing clipboard shuffle path
