### PR TITLE
Prepare the 0.2.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,7 +991,7 @@ checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
 name = "emoji-picker"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arboard",
  "log",
@@ -4145,7 +4145,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-desktop-integration"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "gdk",
  "gdkx11",
@@ -4232,7 +4232,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-xdg-portal"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ashpd",
  "futures-util",

--- a/apps/emoji-picker/package.json
+++ b/apps/emoji-picker/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@emoji-picker/emoji-picker",
 	"private": true,
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "Emoji Nook desktop application frontend",
 	"license": "(Apache-2.0 OR MIT)",
 	"type": "module",

--- a/apps/emoji-picker/src-tauri/Cargo.toml
+++ b/apps/emoji-picker/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emoji-picker"
-version = "0.1.0"
+version = "0.2.0"
 description = "A native Linux emoji picker that blends with your desktop"
 authors = ["Liminal HQ, Scott Morris"]
 license.workspace = true

--- a/apps/emoji-picker/src-tauri/tauri.conf.json
+++ b/apps/emoji-picker/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Emoji Nook",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"identifier": "ca.liminalhq.emoji-nook",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -18,10 +18,12 @@ The following files should move together for each app release:
 - `apps/emoji-picker/package.json`
 - `apps/emoji-picker/src-tauri/tauri.conf.json`
 - `apps/emoji-picker/src-tauri/Cargo.toml`
+- `plugins/desktop-integration/Cargo.toml`
+- `plugins/desktop-integration/guest-js/package.json`
 - `plugins/xdg-portal/Cargo.toml`
 - `plugins/xdg-portal/guest-js/package.json`
 
-This keeps the desktop app, the local Rust plugin crate, and the guest JavaScript package aligned while the plugin remains an internal workspace component rather than a separately published product.
+This keeps the desktop app, the local Rust plugin crates, and the guest JavaScript packages aligned while the plugins remain internal workspace components rather than separately published products.
 
 ## Maintainer commands
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -25,6 +25,8 @@ The following files should move together for each app release:
 
 This keeps the desktop app, the local Rust plugin crates, and the guest JavaScript packages aligned while the plugins remain internal workspace components rather than separately published products.
 
+When those manifest versions change, `Cargo.lock` should be refreshed in the same release-preparation pass so `cargo ... --locked` validation keeps working on the release branch.
+
 ## Maintainer commands
 
 Use these helpers when preparing or validating a release:
@@ -36,7 +38,7 @@ pnpm release:version:prepare -- --version 0.2.0
 pnpm release:version:prepare -- --version 0.2.0 --dry-run
 ```
 
-The release-prep helper creates `chore/release-vX.Y.Z` by default, updates all release-facing version fields together, and refuses to run on a dirty working tree.
+The release-prep helper creates `chore/release-vX.Y.Z` by default, updates all release-facing version fields together, refreshes `Cargo.lock`, and refuses to run on a dirty working tree.
 
 ## Tags and branches
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "emoji-picker-workspace",
 	"private": true,
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "Emoji Nook workspace for the desktop app and XDG portal plugin",
 	"license": "(Apache-2.0 OR MIT)",
 	"packageManager": "pnpm@9.15.0",

--- a/plugins/desktop-integration/Cargo.toml
+++ b/plugins/desktop-integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-desktop-integration"
-version = "0.1.0"
+version = "0.2.0"
 description = "Desktop activation helpers for Emoji Nook"
 authors = ["Liminal HQ, Scott Morris"]
 license.workspace = true

--- a/plugins/desktop-integration/guest-js/package.json
+++ b/plugins/desktop-integration/guest-js/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tauri-plugin-desktop-integration",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "Guest JavaScript bindings for the Emoji Nook desktop-integration plugin",
 	"license": "(Apache-2.0 OR MIT)",
 	"type": "module",

--- a/plugins/xdg-portal/Cargo.toml
+++ b/plugins/xdg-portal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-xdg-portal"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license.workspace = true
 description = "Tauri plugin for xdg-desktop-portal integrations"

--- a/plugins/xdg-portal/guest-js/package.json
+++ b/plugins/xdg-portal/guest-js/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tauri-plugin-xdg-portal",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "Guest JavaScript bindings for the Emoji Nook XDG portal plugin",
 	"license": "(Apache-2.0 OR MIT)",
 	"type": "module",

--- a/scripts/check-release-versions.sh
+++ b/scripts/check-release-versions.sh
@@ -72,6 +72,8 @@ FILE_SPECS=(
     "Desktop package.json|apps/emoji-picker/package.json|json"
     "Tauri config|apps/emoji-picker/src-tauri/tauri.conf.json|json"
     "Desktop Cargo manifest|apps/emoji-picker/src-tauri/Cargo.toml|toml"
+    "Desktop integration Cargo manifest|plugins/desktop-integration/Cargo.toml|toml"
+    "Desktop integration guest JS package|plugins/desktop-integration/guest-js/package.json|json"
     "Plugin Cargo manifest|plugins/xdg-portal/Cargo.toml|toml"
     "Plugin guest JS package|plugins/xdg-portal/guest-js/package.json|json"
 )

--- a/scripts/prepare-release-version.sh
+++ b/scripts/prepare-release-version.sh
@@ -136,6 +136,8 @@ FILES=(
     "apps/emoji-picker/package.json"
     "apps/emoji-picker/src-tauri/tauri.conf.json"
     "apps/emoji-picker/src-tauri/Cargo.toml"
+    "plugins/desktop-integration/Cargo.toml"
+    "plugins/desktop-integration/guest-js/package.json"
     "plugins/xdg-portal/Cargo.toml"
     "plugins/xdg-portal/guest-js/package.json"
 )
@@ -174,6 +176,8 @@ write_json_version "${REPO_ROOT}/package.json" "${NEW_VERSION}"
 write_json_version "${REPO_ROOT}/apps/emoji-picker/package.json" "${NEW_VERSION}"
 write_json_version "${REPO_ROOT}/apps/emoji-picker/src-tauri/tauri.conf.json" "${NEW_VERSION}"
 write_toml_version "${REPO_ROOT}/apps/emoji-picker/src-tauri/Cargo.toml" "${CURRENT_VERSION}" "${NEW_VERSION}"
+write_toml_version "${REPO_ROOT}/plugins/desktop-integration/Cargo.toml" "${CURRENT_VERSION}" "${NEW_VERSION}"
+write_json_version "${REPO_ROOT}/plugins/desktop-integration/guest-js/package.json" "${NEW_VERSION}"
 write_toml_version "${REPO_ROOT}/plugins/xdg-portal/Cargo.toml" "${CURRENT_VERSION}" "${NEW_VERSION}"
 write_json_version "${REPO_ROOT}/plugins/xdg-portal/guest-js/package.json" "${NEW_VERSION}"
 

--- a/scripts/prepare-release-version.sh
+++ b/scripts/prepare-release-version.sh
@@ -72,6 +72,16 @@ write_toml_version() {
     perl -0pi -e 's/^version = "\Q'"${current_version}"'\E"$/version = "'"${new_version}"'"/m' "$file_path"
 }
 
+refresh_cargo_lock() {
+    local lockfile_path="${REPO_ROOT}/Cargo.lock"
+
+    [[ -f "$lockfile_path" ]] || return 0
+
+    info
+    info "Refreshing Cargo.lock for workspace version updates"
+    cargo update --workspace --manifest-path "${REPO_ROOT}/Cargo.toml" >/dev/null
+}
+
 CURRENT_VERSION_ONLY=false
 VERSION_INPUT=""
 BRANCH_INPUT=""
@@ -180,6 +190,7 @@ write_toml_version "${REPO_ROOT}/plugins/desktop-integration/Cargo.toml" "${CURR
 write_json_version "${REPO_ROOT}/plugins/desktop-integration/guest-js/package.json" "${NEW_VERSION}"
 write_toml_version "${REPO_ROOT}/plugins/xdg-portal/Cargo.toml" "${CURRENT_VERSION}" "${NEW_VERSION}"
 write_json_version "${REPO_ROOT}/plugins/xdg-portal/guest-js/package.json" "${NEW_VERSION}"
+refresh_cargo_lock
 
 resolved_version="$("${CHECK_SCRIPT}" --current-version)"
 if [[ "$resolved_version" != "$NEW_VERSION" ]]; then
@@ -191,6 +202,9 @@ info "Updated release-facing versions to ${NEW_VERSION}:"
 for file in "${FILES[@]}"; do
     info "  - ${file}"
 done
+if [[ -f "${REPO_ROOT}/Cargo.lock" ]]; then
+    info "  - Cargo.lock"
+fi
 
 info
 info "Next steps:"


### PR DESCRIPTION
## Summary

### Release prep
- **Version bump:** Update all release-facing workspace manifests from `0.1.0` to `0.2.0`.
- **Desktop plugin coverage:** Include the new `tauri-plugin-desktop-integration` crate and guest package in the coordinated release version bump.
- **Release automation alignment:** Keep the root manifest, app manifests, and both custom plugin manifests synchronised so the release metadata checks and tag workflow operate on one shared release version.

## Test plan

- [x] `pnpm release:version:check`
- [x] `./scripts/check-release-versions.sh --current-version`
- [x] `./scripts/prepare-release-version.sh --version 0.1.1 --dry-run`
